### PR TITLE
add node handling

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -50,6 +50,7 @@ import { default as SigningKey } from './types/signingKey'
 const DEFAULT_QUERY_COUNT = 100
 const DEFAULT_API_URL = 'https://api.e3db.com'
 const EMAIL = /(.+)@(.+){2,}\.(.+){2,}/
+const fs = require('fs')
 
 /* eslint-disable no-buffer-constructor */
 
@@ -126,7 +127,6 @@ async function checkStatus(response) {
   if (response.status >= 200 && response.status < 300) {
     return Promise.resolve(response)
   }
-
   let error = new Error(response.statusText)
   error.response = response
   throw error
@@ -1158,16 +1158,28 @@ const PreClient = crypto => {
       const postJson = await postResponse.json()
       fileObj.fileUrl = postJson.file_url
       fileObj.recordId = postJson.id
+
+      let file
+      if (typeof encryptedFile === 'string') {
+        // Read encrypted file as a stream
+        file = fs.createReadStream(encryptedFile)
+      } else {
+        file = encryptedFile
+      }
+
       // Upload encrypted file to AWS S3 Bucket.
       const putRequest = await fetch(fileObj.fileUrl, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/octet-stream',
-          'Content-MD5': checkSum
+          'Content-MD5': checkSum,
+          'Content-Length': encryptedLength
         },
-        body: encryptedFile
+        body: file
       })
+
       await checkStatus(putRequest)
+
       const patchRequest = await oauthFetch(
         this,
         this.config.apiUrl + `/v1/storage/files/${fileObj.recordId}`,
@@ -1178,6 +1190,7 @@ const PreClient = crypto => {
           }
         }
       )
+
       const patchResponse = await checkStatus(patchRequest)
       const patchJson = await patchResponse.json()
       // Delete the temporary file, here encryptedFile.

--- a/lib/client.js
+++ b/lib/client.js
@@ -1213,7 +1213,6 @@ const PreClient = crypto => {
       let fileResponse = await checkStatus(fileRequest)
 
       // Check if program is running in node
-      console.log('process: ', process)
       if (process.title === 'node') {
         const stream = fs.createWriteStream(file)
         await new Promise((resolve, reject) => {

--- a/lib/client.js
+++ b/lib/client.js
@@ -1128,13 +1128,14 @@ const PreClient = crypto => {
       const patchResponse = await checkStatus(patchRequest)
       const patchJson = await patchResponse.json()
 
-      fs.unlink(encryptedFile, err => {
-        const msg = "ERROR: failed to delete file '" + encryptedFile + "'."
-        if (err) {
-          throw msg
-        }
-      })
-
+      if (typeof encryptedFile === 'string') {
+        fs.unlink(encryptedFile, err => {
+          const msg = "ERROR: failed to delete file '" + encryptedFile + "'."
+          if (err) {
+            throw msg
+          }
+        })
+      }
       return new File(
         patchJson.meta.file_meta.checksum,
         patchJson.meta.file_meta.compression,
@@ -1212,7 +1213,8 @@ const PreClient = crypto => {
       let fileResponse = await checkStatus(fileRequest)
 
       // Check if program is running in node
-      if (typeof process !== undefined && process.release.name === 'node') {
+      console.log('process: ', process)
+      if (process.title === 'node') {
         const stream = fs.createWriteStream(file)
         await new Promise((resolve, reject) => {
           fileResponse.body.pipe(stream)
@@ -1223,8 +1225,11 @@ const PreClient = crypto => {
             resolve()
           })
         })
-      } else {
+      } else if (process.title === 'browser') {
         file = await fileResponse.arrayBuffer()
+      } else {
+        const msg = 'ERROR: platform not recognized'
+        throw msg
       }
 
       const fileName = destinationFilename
@@ -1233,12 +1238,14 @@ const PreClient = crypto => {
 
       const decrypted = await crypto.decryptFile(fileName, ak, file)
 
-      fs.unlink(file, err => {
-        const msg = "ERROR: failed to delete file '" + file + "'."
-        if (err) {
-          throw msg
-        }
-      })
+      if (process.title === 'node') {
+        fs.unlink(file, err => {
+          const msg = "ERROR: failed to delete file '" + file + "'."
+          if (err) {
+            throw msg
+          }
+        })
+      }
 
       // File not yet added to any file system.
       // Returned with the File object.

--- a/lib/client.js
+++ b/lib/client.js
@@ -47,11 +47,12 @@ import { default as RecordData } from './types/recordData'
 import { default as RecordInfo } from './types/recordInfo'
 import { default as SignedDocument } from './types/signedDocument'
 import { default as SigningKey } from './types/signingKey'
+import { default as fs } from 'fs'
 
 const DEFAULT_QUERY_COUNT = 100
 const DEFAULT_API_URL = 'https://api.e3db.com'
 const EMAIL = /(.+)@(.+){2,}\.(.+){2,}/
-const fs = require('fs')
+// Const fs = require('fs')
 
 /**
  * Check the return status of a fetch request and throw an error if one occurred
@@ -1068,6 +1069,7 @@ const PreClient = crypto => {
         fileObject,
         ak
       )
+      console.log('RETURNED')
       const fileCompression = 'raw'
       const fileObj = new File(
         checkSum,
@@ -1096,13 +1098,6 @@ const PreClient = crypto => {
       fileObj.fileUrl = postJson.file_url
       fileObj.recordId = postJson.id
 
-      let file
-      if (typeof encryptedFile === 'string') {
-        // Read encrypted file as a stream
-        file = fs.createReadStream(encryptedFile)
-      } else {
-        file = encryptedFile
-      }
       // Upload encrypted file to AWS S3 Bucket.
       const putRequest = await fetch(fileObj.fileUrl, {
         method: 'PUT',
@@ -1111,7 +1106,7 @@ const PreClient = crypto => {
           'Content-MD5': checkSum,
           'Content-Length': encryptedLength
         },
-        body: file
+        body: encryptedFile
       })
 
       await checkStatus(putRequest)
@@ -1128,14 +1123,8 @@ const PreClient = crypto => {
       const patchResponse = await checkStatus(patchRequest)
       const patchJson = await patchResponse.json()
 
-      if (typeof encryptedFile === 'string') {
-        fs.unlink(encryptedFile, err => {
-          const msg = "ERROR: failed to delete file '" + encryptedFile + "'."
-          if (err) {
-            throw msg
-          }
-        })
-      }
+      // Delete local copy of encrypted file before returning
+
       return new File(
         patchJson.meta.file_meta.checksum,
         patchJson.meta.file_meta.compression,

--- a/lib/client.js
+++ b/lib/client.js
@@ -51,7 +51,6 @@ const DEFAULT_QUERY_COUNT = 100
 const DEFAULT_API_URL = 'https://api.e3db.com'
 const EMAIL = /(.+)@(.+){2,}\.(.+){2,}/
 const fs = require('fs')
-// Const aw = require('awaitify-stream')
 
 /* eslint-disable no-buffer-constructor */
 
@@ -1129,8 +1128,7 @@ const PreClient = crypto => {
       }
       const [encryptedFile, checkSum, encryptedLength] = await crypto.encryptLargeFile(
         fileObject,
-        ak,
-        plainMetadata // Get rid of this ??
+        ak
       )
       const fileCompression = 'raw'
       const fileObj = new File(
@@ -1143,6 +1141,7 @@ const PreClient = crypto => {
         plainMetadata
       )
       const postBody = fileObj.toJson()
+
       // Post file meta to request AWS S3 Bucket URL.
       const postRequest = await oauthFetch(
         this,
@@ -1271,7 +1270,6 @@ const PreClient = crypto => {
       if (ak === null) {
         throw new Error(`Can't read records of type ${fileObj.type}`)
       }
-      // How to upload / fetch the file stream efficiently?
       let file = fileObj.fileName
 
       const fileRequest = await fetch(fileObj.fileUrl, {

--- a/lib/client.js
+++ b/lib/client.js
@@ -51,6 +51,7 @@ const DEFAULT_QUERY_COUNT = 100
 const DEFAULT_API_URL = 'https://api.e3db.com'
 const EMAIL = /(.+)@(.+){2,}\.(.+){2,}/
 const fs = require('fs')
+// Const aw = require('awaitify-stream')
 
 /* eslint-disable no-buffer-constructor */
 
@@ -1129,7 +1130,7 @@ const PreClient = crypto => {
       const [encryptedFile, checkSum, encryptedLength] = await crypto.encryptLargeFile(
         fileObject,
         ak,
-        plainMetadata
+        plainMetadata // Get rid of this ??
       )
       const fileCompression = 'raw'
       const fileObj = new File(
@@ -1166,7 +1167,6 @@ const PreClient = crypto => {
       } else {
         file = encryptedFile
       }
-
       // Upload encrypted file to AWS S3 Bucket.
       const putRequest = await fetch(fileObj.fileUrl, {
         method: 'PUT',
@@ -1193,7 +1193,14 @@ const PreClient = crypto => {
 
       const patchResponse = await checkStatus(patchRequest)
       const patchJson = await patchResponse.json()
-      // Delete the temporary file, here encryptedFile.
+
+      fs.unlink(encryptedFile, err => {
+        const msg = "ERROR: failed to delete file '" + encryptedFile + "'."
+        if (err) {
+          throw msg
+        }
+      })
+
       return new File(
         patchJson.meta.file_meta.checksum,
         patchJson.meta.file_meta.compression,
@@ -1231,8 +1238,10 @@ const PreClient = crypto => {
           }
         }
       )
+
       let getResponse = await checkStatus(getRequest)
       let getJson = await getResponse.json()
+
       // Create File instance.
       const fileObj = new File(
         getJson.meta.file_meta.checksum,
@@ -1249,6 +1258,7 @@ const PreClient = crypto => {
         getJson.meta.last_modified,
         getJson.meta.version
       )
+
       // Get the access key to decrypt the record.
       const ak = await getAccessKey(
         this,
@@ -1262,17 +1272,42 @@ const PreClient = crypto => {
         throw new Error(`Can't read records of type ${fileObj.type}`)
       }
       // How to upload / fetch the file stream efficiently?
+      let file = fileObj.fileName
+
       const fileRequest = await fetch(fileObj.fileUrl, {
         method: 'GET'
       })
       let fileResponse = await checkStatus(fileRequest)
-      let encryptedFileArrayBuffer = await fileResponse.arrayBuffer()
-      // Should take the encryptedFileName and destinationFileName
+
+      // Check if program is running in node
+      if (typeof process !== undefined && process.release.name === 'node') {
+        const stream = fs.createWriteStream(file)
+        await new Promise((resolve, reject) => {
+          fileResponse.body.pipe(stream)
+          fileResponse.body.on('error', err => {
+            reject(err)
+          })
+          stream.on('finish', () => {
+            resolve()
+          })
+        })
+      } else {
+        file = await fileResponse.arrayBuffer()
+      }
+
       const fileName = destinationFilename
         ? destinationFilename
         : getJson.meta.file_meta.file_name
-      const decrypted = await crypto.decryptFile(fileName, ak, encryptedFileArrayBuffer)
-      // Delete the encrypted file.  No longer needed.
+
+      const decrypted = await crypto.decryptFile(fileName, ak, file)
+
+      fs.unlink(file, err => {
+        const msg = "ERROR: failed to delete file '" + file + "'."
+        if (err) {
+          throw msg
+        }
+      })
+
       // File not yet added to any file system.
       // Returned with the File object.
       return [decrypted, fileObj]


### PR DESCRIPTION
- make writeLargeFile and readLargeFile able to work with node and browser sdk
- read stream has been moved from writeLargeFile to encryptLargeFile in the node-sdk. this function returns a stream that can be used in client-interface.
- still needed: a way to get the encrypted file from the api without the file system in readLargeFile. this version still uses the file system until a solution can be found.