### PR TITLE
Add authorizer features to the client interface

### DIFF
--- a/lib/__tests__/newClient.test.js
+++ b/lib/__tests__/newClient.test.js
@@ -720,6 +720,103 @@ describe("Client", () => {
     })
   })
 
+  it("noops add authorizer when the client authorizes them self", async() => {
+    const addAuthorizer = await client1.addAuthorizer(
+      client1.config.clientId,
+      'sharedType'
+    )
+    // if response status successful, returns Promise that resolves true
+    expect(addAuthorizer).toEqual(true)
+  })
+
+  it("add a key and a policy to add an authorizer", async() => {
+    fetch.mockResponses(
+      [
+        JSON.stringify({
+          access_token: "getEAK",
+          expires_at: "xxxxx",
+          authorizer_public_key: { curve25519: "xxx" }
+        })
+      ],
+      [
+        JSON.stringify({
+          clientId: "responseClientId",
+          public_key: { curve25519: "xxxx" },
+          validated: true
+        })
+      ],
+      [
+        JSON.stringify({
+          access_token: "putNewEAK",
+          expires_at: "xxxxx",
+          authorizer_public_key: { curve25519: "xxx" }
+        })
+      ],
+      [JSON.stringify({ body: "" })]
+    )
+
+
+    const addAuthorizer = await client1.addAuthorizer(
+      "clientIdToAuthorize",
+      "recordTypeToAuthorize"
+    )
+
+    // auth token already cached
+    // tries to GET access key, succeeds
+    expect(fetch.mock.calls[0][0]).toEqual(
+      "https://localhost/v1/storage/access_keys/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000/recordTypeToAuthorize"
+    )
+    // GETS from /storage/clients to get public key for the reader
+    expect(fetch.mock.calls[1][0]).toEqual(
+      "https://localhost/v1/storage/clients/clientIdToAuthorize"
+    )
+    // PUTs a new access key for the reader
+    expect(fetch.mock.calls[2][0]).toEqual(
+      "https://localhost/v1/storage/access_keys/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000/clientIdToAuthorize/recordTypeToAuthorize"
+    )
+    // access key in request is encrypted
+    expect(JSON.parse(fetch.mock.calls[2][1].body)).toEqual({
+      eak: "privateKey.EncryptedprivateKey.AccessKey.xxxx"
+    })
+    // PUTs a new policy for the new reader
+    expect(fetch.mock.calls[3][0]).toEqual(
+      "https://localhost/v1/storage/policy/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000/clientIdToAuthorize/recordTypeToAuthorize"
+    )
+
+    expect(JSON.parse(fetch.mock.calls[3][1].body)).toEqual(
+      { allow: [{ authorizer: {} }] }
+    )
+    // if response status successful, returns Promise that resolves true
+    expect(addAuthorizer).toEqual(true)
+  })
+
+  it("removes a key and a policy to add an authorizer", async () => {
+    fetch.mockResponses(
+      [JSON.stringify({ body: "" }), { status: 204 }],
+      [JSON.stringify({ body: "" }), { status: 204 }]
+    )
+
+    const removed = await client1.removeAuthorizer(
+      "clientIdToRemove",
+      "recordTypeToRevoke"
+    )
+
+    // DELETE request to storage/access_keys
+    expect(fetch.mock.calls[0][0]).toEqual(
+      "https://localhost/v1/storage/access_keys/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000/clientIdToRemove/recordTypeToRevoke"
+    )
+        // auth token already cached
+    // PUTS policy deny to /storage/policy
+    expect(fetch.mock.calls[1][0]).toEqual(
+      "https://localhost/v1/storage/policy/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000/clientIdToRemove/recordTypeToRevoke"
+    )
+    expect(JSON.parse(fetch.mock.calls[1][1].body)).toEqual(
+      { deny: [{ authorizer: {} }] }
+    )
+    // returns Promise that resolves true
+    expect(removed).toEqual(true)
+  })
+
   it("shares a record type", async () => {
     fetch.mockResponses(
       [
@@ -780,6 +877,97 @@ describe("Client", () => {
         */
   })
 
+  it("shares a record type on behalf of another writer", async () => {
+    fetch.mockResponses(
+      [
+        JSON.stringify({
+          access_token: "getEAK",
+          expires_at: "xxxxx",
+          authorizer_public_key: { curve25519: "xxx" }
+        })
+      ],
+      [
+        JSON.stringify({
+          clientId: "responseClientId",
+          public_key: { curve25519: "xxxx" },
+          validated: true
+        })
+      ],
+      [
+        JSON.stringify({
+          access_token: "putNewEAK",
+          expires_at: "xxxxx",
+          authorizer_public_key: { curve25519: "xxx" }
+        })
+      ],
+      [JSON.stringify({ body: "" })]
+    )
+
+    const share = await client1.shareOnBehalfOf(
+      "sharedWriterId",
+      "recordTypeToShare",
+      "clientIdToShareWith"
+    )
+
+    // auth token already cached
+    // tries to GET access key, succeeds
+    expect(fetch.mock.calls[0][0]).toEqual(
+      "https://localhost/v1/storage/access_keys/sharedWriterId/sharedWriterId/00000000-0000-0000-0000-000000000000/recordTypeToShare"
+    )
+    // GETS from /storage/clients to get public key for the reader
+    expect(fetch.mock.calls[1][0]).toEqual(
+      "https://localhost/v1/storage/clients/clientIdToShareWith"
+    )
+    // PUTs a new access key for the reader
+    expect(fetch.mock.calls[2][0]).toEqual(
+      "https://localhost/v1/storage/access_keys/sharedWriterId/sharedWriterId/clientIdToShareWith/recordTypeToShare"
+    )
+    // access key in request is encrypted
+    expect(JSON.parse(fetch.mock.calls[2][1].body)).toEqual({
+      eak: "privateKey.EncryptedprivateKey.AccessKey.xxxx"
+    })
+    // PUTs a new policy for the new reader
+    expect(fetch.mock.calls[3][0]).toEqual(
+      "https://localhost/v1/storage/policy/sharedWriterId/sharedWriterId/clientIdToShareWith/recordTypeToShare"
+    )
+    expect(JSON.parse(fetch.mock.calls[3][1].body)).toEqual(
+      { allow: [{ read: {} }] }
+    )
+    // if response status successful, returns Promise that resolves true
+    expect(share).toEqual(true)
+  })
+
+  it("revokes access to a record type from another writer", async () => {
+    fetch.mockResponses(
+      [JSON.stringify({ body: "" }), { status: 204 }],
+      [JSON.stringify({ body: "" }), { status: 204 }]
+    )
+
+    const revoked = await client1.revokeOnBehalfOf(
+      "sharedWriterId",
+      "recordTypeToRevoke",
+      "clientIdToRevokeFrom"
+    )
+    // DELETE request to storage/access_keys
+    expect(fetch.mock.calls[0][0]).toEqual(
+      "https://localhost/v1/storage/access_keys/sharedWriterId/sharedWriterId/clientIdToRevokeFrom/recordTypeToRevoke"
+    )
+        // auth token already cached
+    // PUTS policy deny to /storage/policy
+    expect(fetch.mock.calls[1][0]).toEqual(
+      "https://localhost/v1/storage/policy/sharedWriterId/sharedWriterId/clientIdToRevokeFrom/recordTypeToRevoke"
+    )
+    expect(JSON.parse(fetch.mock.calls[1][1].body)).toEqual(
+      { deny: [{ read: {} }] }
+    )
+    // returns Promise that resolves true
+    expect(revoked).toEqual(true)
+
+    /*
+            could test email passed as param
+        */
+  })
+
   it("revokes (unshares) a record type", async () => {
     fetch.mockResponses(
       [JSON.stringify({ body: "" }), { status: 204 }],
@@ -790,15 +978,14 @@ describe("Client", () => {
       "recordTypeToRevoke",
       "clientIdToRevokeFrom"
     )
-
-    // auth token already cached
-    // PUTS policy deny to /storage/policy
-    expect(fetch.mock.calls[0][0]).toEqual(
-      "https://localhost/v1/storage/policy/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000/clientIdToRevokeFrom/recordTypeToRevoke"
-    )
     // DELETE request to storage/access_keys
-    expect(fetch.mock.calls[1][0]).toEqual(
+    expect(fetch.mock.calls[0][0]).toEqual(
       "https://localhost/v1/storage/access_keys/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000/clientIdToRevokeFrom/recordTypeToRevoke"
+    )
+        // auth token already cached
+    // PUTS policy deny to /storage/policy
+    expect(fetch.mock.calls[1][0]).toEqual(
+      "https://localhost/v1/storage/policy/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000/clientIdToRevokeFrom/recordTypeToRevoke"
     )
     // returns Promise that resolves true
     expect(revoked).toEqual(true)
@@ -806,6 +993,92 @@ describe("Client", () => {
     /*
             could test email passed as param
         */
+  })
+
+  it("fetches authorizer policies written for other clients", async () => {
+    fetch.mockResponses(
+      [
+        JSON.stringify([
+          {
+            authorizer_id: 'authorizer1',
+            writer_id: 'clientID',
+            user_id: 'clientID',
+            record_type: 'type1',
+            authorized_by: 'clientID'
+          },
+          {
+            authorizer_id: 'authorizer2',
+            writer_id: 'clientID',
+            user_id: 'clientID',
+            record_type: 'type2',
+            authorized_by: 'clientID'
+          }
+        ])
+      ]
+    )
+    const authorizers = await client1.getAuthorizers()
+
+    // GET request to /v1/storage/policy/proxies
+    expect(fetch.mock.calls[0][0]).toEqual(
+      "https://localhost/v1/storage/policy/proxies"
+    )
+    expect(Array.isArray(authorizers)).toBe(true)
+    expect(authorizers.length).toBe(2)
+    // first item
+    expect(authorizers[0].authorizerId).toBe('authorizer1')
+    expect(authorizers[0].writerId).toBe('clientID')
+    expect(authorizers[0].userId).toBe('clientID')
+    expect(authorizers[0].recordType).toBe('type1')
+    expect(authorizers[0].authorizedBy).toBe('clientID')
+    // second item
+    expect(authorizers[1].authorizerId).toBe('authorizer2')
+    expect(authorizers[1].writerId).toBe('clientID')
+    expect(authorizers[1].userId).toBe('clientID')
+    expect(authorizers[1].recordType).toBe('type2')
+    expect(authorizers[1].authorizedBy).toBe('clientID')
+  })
+
+  it("fetches authorizer policies written from other clients", async () => {
+    fetch.mockResponses(
+      [
+        JSON.stringify([
+          {
+            authorizer_id: 'clientID',
+            writer_id: 'otherClient1',
+            user_id: 'otherClient1',
+            record_type: 'type1',
+            authorized_by: 'otherClient1'
+          },
+          {
+            authorizer_id: 'clientID',
+            writer_id: 'otherClient2',
+            user_id: 'otherClient2',
+            record_type: 'type2',
+            authorized_by: 'otherClient2'
+          }
+        ])
+      ]
+    )
+    const authorizers = await client1.getAuthorizedBy()
+
+    // GET request to /v1/storage/policy/proxies
+    expect(fetch.mock.calls[0][0]).toEqual(
+      "https://localhost/v1/storage/policy/granted"
+    )
+    expect(Array.isArray(authorizers)).toBe(true)
+    expect(authorizers.length).toBe(2)
+    // first item
+    expect(authorizers[0].authorizerId).toBe('clientID')
+    expect(authorizers[0].writerId).toBe('otherClient1')
+    expect(authorizers[0].userId).toBe('otherClient1')
+    expect(authorizers[0].recordType).toBe('type1')
+    expect(authorizers[0].authorizedBy).toBe('otherClient1')
+    // second item
+    expect(authorizers[1].authorizerId).toBe('clientID')
+    expect(authorizers[1].writerId).toBe('otherClient2')
+    expect(authorizers[1].userId).toBe('otherClient2')
+    expect(authorizers[1].recordType).toBe('type2')
+    expect(authorizers[1].authorizedBy).toBe('otherClient2')
   })
 
   it("serializes in the proper order", () => {

--- a/lib/storage/client.js
+++ b/lib/storage/client.js
@@ -32,6 +32,7 @@ import Config from './config'
 import { checkStatus } from '../utils'
 import { DEFAULT_API_URL, DEFAULT_QUERY_COUNT, EMAIL } from '../utils/constants'
 import {
+  AuthorizerPolicy,
   ClientDetails,
   ClientInfo,
   EAKInfo,
@@ -170,6 +171,32 @@ async function putAccessKey(client, writerId, userId, readerId, type, ak) {
 }
 
 /**
+ * Create an access key for another reader, creating one for this client as needed.
+ *
+ * @param {Client} client TozStore client instance
+ * @param {string} writerId Writer/Authorizer for the access key
+ * @param {string} readerId Authorized reader
+ * @param {string} type     Record type for which the key will be used
+ *
+ * @returns {Promise<bool>} Whether the access key was written successfully
+ */
+async function putAccessKeyForReader(client, writerId, type, readerId) {
+  // Get current access key, create one if it is missing
+  let clientId = client.config.clientId
+  let ak = await getAccessKey(client, writerId, writerId, clientId, type)
+  if (ak === null) {
+    if (clientId === writerId) {
+      ak = await client.crypto.randomKey()
+      await putAccessKey(client, clientId, clientId, clientId, type, ak)
+    } else {
+      throw new Error('Missing access key required for share operation')
+    }
+  }
+  // Create an access key for the new reader
+  await putAccessKey(client, writerId, writerId, readerId, type, ak)
+}
+
+/**
  * Delete an access key on the server.
  *
  * @param {Client} client   E3DB client instance
@@ -204,6 +231,41 @@ async function deleteAccessKey(client, writerId, userId, readerId, type) {
   let cacheKey = `${writerId}.${userId}.${type}`
   delete client._akCache[cacheKey]
 
+  return true
+}
+
+/**
+ * Add or update an policy to the TozStore storage service
+ *
+ * @param {Client} client   TozStore Client instance
+ * @param {object} policy   An object containing the policy definition to write
+ * @param {string} writerId Writer/Authorizer controlling data access
+ * @param {string} userId   The client ID of the subject of the protected data
+ * @param {string} readerId The client ID whose access is being updated
+ * @param {string} type     Record type for which the policy will be used
+ *
+ * @returns {Promise<bool>} Whether the policy was written successfully
+ */
+async function putPolicy(client, policy, writerId, userId, readerId, type) {
+  let request = await client.authenticator.tokenFetch(
+    client.config.apiUrl +
+      '/v1/storage/policy/' +
+      writerId +
+      '/' +
+      userId +
+      '/' +
+      readerId +
+      '/' +
+      type,
+    {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(policy)
+    }
+  )
+  await checkStatus(request)
   return true
 }
 
@@ -1144,6 +1206,46 @@ export default class Client extends CryptoConsumer {
   }
 
   /**
+   * Allow another client to grant read access this client's records of a specific type
+   *
+   * @param {string} authorizerId The client ID to grant sharing privileges to
+   * @param {string} type The record type to grant sharing access for
+   *
+   * @returns {Promise<bool>} Whether the authorizer was added successfully.
+   */
+  async addAuthorizer(authorizerId, type) {
+    const clientId = this.config.clientId
+    if (authorizerId === clientId) {
+      return true
+    }
+
+    await putAccessKeyForReader(this, clientId, type, authorizerId)
+
+    const policy = { allow: [{ authorizer: {} }] }
+    return putPolicy(this, policy, clientId, clientId, authorizerId, type)
+  }
+
+  /**
+   * Remove another client's ability to grant read access this client's records of a specific type
+   *
+   * @param {string} authorizerId The client ID to revoke sharing privileges from
+   * @param {string} type The record type to revoke sharing access for
+   *
+   * @returns {Promise<bool>} Whether the authorizer was removed successfully.
+   */
+  async removeAuthorizer(authorizerId, type) {
+    const clientId = this.config.clientId
+    if (authorizerId === clientId) {
+      return true
+    }
+
+    await deleteAccessKey(this, clientId, clientId, authorizerId, type)
+
+    const policy = { deny: [{ authorizer: {} }] }
+    return putPolicy(this, policy, clientId, clientId, authorizerId, type)
+  }
+
+  /**
    * Grant another E3DB client access to records of a particular type.
    *
    * @param {string} type     Type of records to share
@@ -1152,49 +1254,31 @@ export default class Client extends CryptoConsumer {
    * @returns {Promise<bool>}
    */
   async share(type, readerId) {
-    if (readerId === this.config.clientId) {
-      return Promise.resolve(true)
-    }
     if (EMAIL.test(readerId)) {
       let clientInfo = await this.clientInfo(readerId)
       return this.share(type, clientInfo.clientId)
     }
+    // Share on behalf of ourself
+    return this.shareOnBehalfOf(this.config.clientId, type, readerId)
+  }
 
-    let clientId = this.config.clientId
-    let ak = await getAccessKey(this, clientId, clientId, clientId, type)
-    if (ak === null) {
-      ak = await this.crypto.randomKey()
-      await putAccessKey(
-        this,
-        this.config.clientId,
-        this.config.clientId,
-        this.config.clientId,
-        type,
-        ak
-      )
+  /**
+   * Grant another E3DB client access to records of a particular type for a writer.
+   *
+   * @param {string} writerId Client ID of the writer to grant for
+   * @param {string} type     Type of records to share
+   * @param {string} readerId Client ID or reader to grant access to
+   *
+   * @returns {Promise<bool>}
+   */
+  async shareOnBehalfOf(writerId, type, readerId) {
+    // Don't need to share if the reader is the writer
+    if (readerId === writerId) {
+      return true
     }
-    await putAccessKey(this, clientId, clientId, readerId, type, ak)
-    let policy = { allow: [{ read: {} }] }
-    let request = await this.authenticator.tokenFetch(
-      this.config.apiUrl +
-        '/v1/storage/policy/' +
-        clientId +
-        '/' +
-        clientId +
-        '/' +
-        readerId +
-        '/' +
-        type,
-      {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify(policy)
-      }
-    )
-    await checkStatus(request)
-    return Promise.resolve(true)
+    await putAccessKeyForReader(this, writerId, type, readerId)
+    const policy = { allow: [{ read: {} }] }
+    return putPolicy(this, policy, writerId, writerId, readerId, type)
   }
 
   /**
@@ -1206,40 +1290,32 @@ export default class Client extends CryptoConsumer {
    * @returns {Promise<bool>}
    */
   async revoke(type, readerId) {
-    if (readerId === this.config.clientId) {
-      return Promise.resolve(true)
-    }
     if (EMAIL.test(readerId)) {
       let clientInfo = await this.clientInfo(readerId)
       return this.revoke(type, clientInfo.clientId)
     }
 
-    let clientId = this.config.clientId
-    let policy = { deny: [{ read: {} }] }
-    let request = await this.authenticator.tokenFetch(
-      this.config.apiUrl +
-        '/v1/storage/policy/' +
-        clientId +
-        '/' +
-        clientId +
-        '/' +
-        readerId +
-        '/' +
-        type,
-      {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify(policy)
-      }
-    )
-    await checkStatus(request)
+    // Revoke on behalf of self
+    return this.revokeOnBehalfOf(this.config.clientId, type, readerId)
+  }
 
+  /**
+   * Revoke another E3DB client's access to records of a particular writer and type.
+   *
+   * @param {string} writerId Client ID of the writer to revoke access to
+   * @param {string} type     Type of records to revoke share for
+   * @param {string} readerId Client ID of reader to revoke access from
+   *
+   * @returns {Promise<bool>}
+   */
+  async revokeOnBehalfOf(writerId, type, readerId) {
+    if (readerId === writerId) {
+      return true
+    }
     // Delete any existing access keys
-    await deleteAccessKey(this, clientId, clientId, readerId, type)
-
-    return Promise.resolve(true)
+    await deleteAccessKey(this, writerId, writerId, readerId, type)
+    let policy = { deny: [{ read: {} }] }
+    return putPolicy(this, policy, writerId, writerId, readerId, type)
   }
 
   /**
@@ -1282,6 +1358,38 @@ export default class Client extends CryptoConsumer {
     let json = await response.json()
 
     return Promise.all(json.map(IncomingSharingPolicy.decode))
+  }
+
+  async getAuthorizers() {
+    const request = await this.authenticator.tokenFetch(
+      this.config.apiUrl + '/v1/storage/policy/proxies',
+      {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }
+    )
+    const response = await checkStatus(request)
+    const proxies = await response.json()
+
+    return proxies.map(AuthorizerPolicy.decode)
+  }
+
+  async getAuthorizedBy() {
+    const request = await this.authenticator.tokenFetch(
+      this.config.apiUrl + '/v1/storage/policy/granted',
+      {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }
+    )
+    const response = await checkStatus(request)
+    const granted = await response.json()
+
+    return granted.map(AuthorizerPolicy.decode)
   }
 
   async writeLargeFile(recordType, fileObject, plainMetadata = {}) {

--- a/lib/types/authorizerPolicy.js
+++ b/lib/types/authorizerPolicy.js
@@ -1,0 +1,61 @@
+/*!
+ * Tozny e3db
+ *
+ * LICENSE
+ *
+ * Tozny dual licenses this product. For commercial use, please contact
+ * info@tozny.com. For non-commercial use, the contents of this file are
+ * subject to the TOZNY NON-COMMERCIAL LICENSE (the "License") which
+ * permits use of the software only by government agencies, schools,
+ * universities, non-profit organizations or individuals on projects that
+ * do not receive external funding other than government research grants
+ * and contracts.  Any other use requires a commercial license. You may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at https://tozny.com/legal/non-commercial-license.
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations under
+ * the License. Portions of the software are Copyright (c) TOZNY LLC, 2018-19.
+ * All rights reserved.
+ *
+ * @copyright Copyright (c) 2018-19 Tozny, LLC (https://tozny.com)
+ */
+
+'use strict'
+
+/**
+ * Information an authorizer policy written to TozStore
+ *
+ * @property {string} authorizerId The Client ID controlled by the policy
+ * @property {string} writerId The client ID that wrote the data controlled by the policy
+ * @property {string} userId The client ID the data controlled by the policy is about
+ * @property {string} recordType The record type controlled by the policy
+ * @property {string} authorizedBy The Client ID that wrote the policy
+ */
+export default class AuthorizerPolicy {
+  constructor(authorizerId, writerId, userId, recordType, authorizedBy) {
+    this.authorizerId = authorizerId
+    this.writerId = writerId
+    this.userId = userId
+    this.recordType = recordType
+    this.authorizedBy = authorizedBy
+  }
+
+  /**
+   * Specify how an already unserialized JSON array should be marshaled into
+   * an object representation.
+   *
+   * @param {object} json
+   *
+   * @return {Promise<AuthorizerPolicy>}
+   */
+  static decode(json) {
+    return new AuthorizerPolicy(
+      json.authorizer_id,
+      json.writer_id,
+      json.user_id,
+      json.record_type,
+      json.authorized_by
+    )
+  }
+}

--- a/lib/types/authorizerPolicy.js
+++ b/lib/types/authorizerPolicy.js
@@ -47,7 +47,7 @@ export default class AuthorizerPolicy {
    *
    * @param {object} json
    *
-   * @return {Promise<AuthorizerPolicy>}
+   * @return {AuthorizerPolicy}
    */
   static decode(json) {
     return new AuthorizerPolicy(

--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -16,6 +16,7 @@
 
 'use strict'
 
+export { default as AuthorizerPolicy } from './authorizerPolicy'
 export { default as ClientDetails } from './clientDetails'
 export { default as ClientInfo } from './clientInfo'
 export { default as EAKInfo } from './eakInfo'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "e3db-client-interface",
-  "version": "0.3.0-alpha.5",
+  "version": "0.3.0-alpha.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7485,10 +7485,9 @@
       }
     },
     "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-      "dev": true
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "e3db-client-interface",
-  "version": "0.3.0-alpha.6",
+  "version": "0.3.0-alpha.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "e3db-client-interface",
-  "version": "0.3.0-alpha.5",
+  "version": "0.3.0-alpha.6",
   "description": "JavaScript client interface for E3DB JS SDKs",
   "homepage": "https://github.com/tozny/js-sdk-client-interface",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "e3db-client-interface",
-  "version": "0.3.0-alpha.6",
+  "version": "0.3.0-alpha.7",
   "description": "JavaScript client interface for E3DB JS SDKs",
   "homepage": "https://github.com/tozny/js-sdk-client-interface",
   "author": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "base64url": "^3.0.1",
     "dotenv": "^6.1.0",
     "es6-promise": "^4.2.4",
-    "isomorphic-fetch": "^2.2"
+    "isomorphic-fetch": "^2.2",
+    "uuid": "^3.3.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.5.0",


### PR DESCRIPTION
Feature and tests to add authorizer functionality to our JS SDKs.

This is mock tested -- which actually caught and fixed several bugs, yay tests! Next step is consuming it in a concrete SDK and testing it there. The plan is to take this on tomorrow - probably using the Node SDK.

On a positive note, none of the crypto or other platform specific items need updates, so the SDKs just need to consume the new interface to enable the authorizer functionality.