### PR TITLE
Fix/broker updates

### DIFF
--- a/lib/identity/client.js
+++ b/lib/identity/client.js
@@ -73,11 +73,11 @@ export default class Client {
     }
   }
 
-  async changePassword(username, newPassword) {
+  async changePassword(newPassword) {
     const newCreds = await deriveNoteCreds(
       this.config,
-      this._crypto,
-      username,
+      this.crypto,
+      this.config.username,
       newPassword
     )
     // Write new credentials (change password)

--- a/lib/identity/config.js
+++ b/lib/identity/config.js
@@ -26,11 +26,7 @@
 import { DEFAULT_API_URL } from '../utils/constants'
 
 /**
- * Configuration and credentials for E3DB.
- *
- * @property {string} realmName The realm's globally unique name
- * @property {string} userId    The specific realm users unique identifier
- * @property {string} [apiUrl]  Optional base URL for the Tozny Platform API
+ * Configuration for communicating with the Tozny Identity service.
  */
 export default class Config {
   /**
@@ -57,24 +53,33 @@ export default class Config {
       }
     }
     const realmName = obj.realmName || obj.realm_name
+    const username = obj.username
     const userId = obj.userId || obj.user_id
     const apiUrl = obj.apiUrl || obj.api_url
     const brokerTargetUrl = obj.brokerTargetUrl || obj.broker_target_url
-    return new this(realmName, userId, apiUrl, brokerTargetUrl)
+    return new this(realmName, apiUrl, username, userId, brokerTargetUrl)
   }
 
   /**
    * Create a new instance of Config
    *
    * @param {string} realmName       The realms globally unique name
-   * @param {string} userId          A specific realm user's unique identifier
    * @param {string} [apiUrl]        Optional base URL for the Tozny Platform API
+   * @param {string} username        The user defined identifier for the user
+   * @param {string} userId          A specific realm user's unique identifier
    * @param {string} brokerTargetUrl The URL which will process broker-based login flows.
    *
    * @returns {Config} The constructed Config object.
    */
-  constructor(realmName, userId, apiUrl = DEFAULT_API_URL, brokerTargetUrl) {
+  constructor(
+    realmName,
+    apiUrl = DEFAULT_API_URL,
+    username,
+    userId,
+    brokerTargetUrl
+  ) {
     this.realmName = realmName
+    this.username = username
     this.userId = userId
     this.apiUrl = apiUrl
     this.brokerTargetUrl = brokerTargetUrl

--- a/lib/identity/index.js
+++ b/lib/identity/index.js
@@ -26,7 +26,7 @@
 import Client from './client'
 import Config from './config'
 import 'isomorphic-fetch'
-import { validateResponseAsJSON, trimSlash } from '../utils'
+import { validateResponseAsJSON, trimSlash, checkStatus } from '../utils'
 import { deriveNoteCreds } from '../utils/credentials'
 import CryptoConsumer from '../utils/cryptoConsumer'
 import { Config as StorageConfig } from '../storage'
@@ -389,7 +389,8 @@ export default class Identity extends CryptoConsumer {
       },
       body: JSON.stringify(payload),
     })
-    return validateResponseAsJSON(request)
+    await checkStatus(request)
+    return request.status === 200 ? request.json() : true
   }
 
   /**

--- a/lib/identity/index.js
+++ b/lib/identity/index.js
@@ -26,26 +26,11 @@
 import Client from './client'
 import Config from './config'
 import 'isomorphic-fetch'
-import { validateResponseAsJSON } from '../utils'
+import { validateResponseAsJSON, trimSlash } from '../utils'
 import { deriveNoteCreds } from '../utils/credentials'
 import CryptoConsumer from '../utils/cryptoConsumer'
 import { Config as StorageConfig } from '../storage'
 import { PublicKey, SigningKey } from '../types'
-
-/**
- * Create a identity client connection from the passed identity values.
- *
- * @param {Identity} id The Identity instance connected to a specific realm.
- * @param {string} userId The specific user ID for the user in the configured realm.
- * @param {StorageConfig} storageConfig The storage client configuration.
- *
- * @return {Client} The identity client ready to run identity methods on behalf of a user.
- */
-function createClient(id, userId, storageConfig) {
-  const idConfig = id.config.clone({ userId: userId })
-  const storageClient = new id.StorageClient(storageConfig)
-  return new Client(idConfig, storageClient, id.crypto)
-}
 
 /**
  * Identity represents a connection to the Tozny Identity service on behalf of a realm.
@@ -167,20 +152,19 @@ export default class Identity extends CryptoConsumer {
       body: JSON.stringify(payload),
     })
     const json = await validateResponseAsJSON(request)
-    const idClient = createClient(
-      this,
-      json.identity.id,
-      new StorageConfig(
-        json.identity.tozny_id,
-        json.identity.api_key_id,
-        json.identity.api_secret_key,
-        cryptoKeys.publicKey,
-        cryptoKeys.privateKey,
-        this.config.apiUrl,
-        signingKeys.publicKey,
-        signingKeys.privateKey
-      )
+    const idConfig = this.config.clone({ username, userId: json.identity.id })
+    const storageClientConfig = new StorageConfig(
+      json.identity.tozny_id,
+      json.identity.api_key_id,
+      json.identity.api_secret_key,
+      cryptoKeys.publicKey,
+      cryptoKeys.privateKey,
+      this.config.apiUrl,
+      signingKeys.publicKey,
+      signingKeys.privateKey
     )
+    const storageClient = new this.StorageClient(storageClientConfig)
+    const idClient = new Client(idConfig, storageClient, this.crypto)
     // Login note
     const { noteID, cryptoKeyPair, signingKeyPair } = await deriveNoteCreds(
       this.config,
@@ -286,15 +270,16 @@ export default class Identity extends CryptoConsumer {
       signingKeyPair,
       this.config.apiUrl
     )
-    const idConfig = Config.fromObject(storedCreds.data.config)
 
-    /* eslint-disable-next-line no-warning-comments */
-    // TODO: Validate creds match this realm before instantiating
-    return createClient(
-      this,
-      idConfig.userId,
-      StorageConfig.fromObject(storedCreds.data.storageConfig)
-    )
+    const user = this.fromObject(storedCreds.data)
+
+    // Backwards compatibility for any identity user whose username was not
+    // written to the credentials note.
+    if (user.config.username !== username) {
+      user.config.username = username
+    }
+
+    return user
   }
 
   /**
@@ -309,6 +294,7 @@ export default class Identity extends CryptoConsumer {
    * @return {Client} The reconstituted identity client for the user.
    */
   fromObject(obj) {
+    // Allow JSON string objects for ease of use.
     if (typeof obj === 'string') {
       try {
         obj = JSON.parse(obj)
@@ -318,6 +304,7 @@ export default class Identity extends CryptoConsumer {
         )
       }
     }
+    // Ensure object shape is generally correct
     if (!obj.config) {
       throw new Error(
         'To create an identity client from an object it must contain identity configuration'
@@ -328,13 +315,24 @@ export default class Identity extends CryptoConsumer {
         'To create an identity client from an object it must contain storageConfig with valid Storage Client configuration'
       )
     }
-    /* eslint-disable-next-line no-warning-comments */
-    // TODO: Validate creds match this realm before instantiating
-    return createClient(
-      this,
-      obj.config.userId,
-      StorageConfig.fromObject(obj.storageConfig)
-    )
+
+    // Set up identity client config
+    const idConfig = this.constructor.Config.fromObject(obj.config)
+    // Validate the configuration matches this realm
+    if (trimSlash(idConfig.apiUrl) !== trimSlash(this.config.apiUrl)) {
+      throw new Error('The client and realm must use the same api url')
+    }
+    if (idConfig.realmName !== this.config.realmName) {
+      throw new Error(
+        'only clients from the configured realm can be instantiated.'
+      )
+    }
+
+    // Set up storage client
+    const storageClientConfig = StorageConfig.fromObject(obj.storageConfig)
+    const storageClient = new this.StorageClient(storageClientConfig)
+    // Create the realm client
+    return new Client(idConfig, storageClient, this.crypto)
   }
 
   /**

--- a/lib/identity/index.js
+++ b/lib/identity/index.js
@@ -359,7 +359,9 @@ export default class Identity extends CryptoConsumer {
    * @return{Promise<Client>} The recovered identity Client.
    */
   completeRecovery(otp, noteId, recoveryUrl) {
-    return this.completeBrokerLogin(otp, noteId, recoveryUrl)
+    /* eslint-disable camelcase */
+    return this.completeBrokerLogin({ email_otp: otp }, noteId, recoveryUrl)
+    /* eslint-enable */
   }
 
   /**
@@ -420,8 +422,8 @@ export default class Identity extends CryptoConsumer {
     const payload = {
       auth_response: authResponse,
       note_id: noteId,
-      public_key: new PublicKey(cryptoKeys.publicKey),
-      signing_key: new SigningKey(signingKeys.publicKey),
+      public_key: cryptoKeys.publicKey,
+      signing_key: signingKeys.publicKey,
       action: 'login',
     }
     /* eslint-enable */

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -108,3 +108,14 @@ export function urlEncodeData(element, key, processed = []) {
   }
   return processed.join('&')
 }
+
+/**
+ * Trim the trailing slash from a string to help enforce url consistency.
+ *
+ * @param {string} path The input string to trim the trailing slash from
+ *
+ * @return {string} The string with any trailing slash removed
+ */
+export function trimSlash(str) {
+  return str.replace(/\/$/, '')
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "e3db-client-interface",
-  "version": "0.3.0-alpha.10",
+  "version": "0.3.0-alpha.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "e3db-client-interface",
-  "version": "0.3.0-alpha.10",
+  "version": "0.3.0-alpha.11",
   "description": "JavaScript client interface for E3DB JS SDKs",
   "homepage": "https://github.com/tozny/js-sdk-client-interface",
   "author": {


### PR DESCRIPTION
This modifies how some of the identity functionality is stacked, helping ensure full compatibility with the broker flow. Most notably, the username is now included in the identity user's config, and is no longer a required parameter for the `changePassword` method. This is done with backwards compatibility so that we can offer proper brokering even if clients signed up before using this client interface version.