### PR TITLE
Update config requiring an application for identity services

### DIFF
--- a/lib/identity/client.js
+++ b/lib/identity/client.js
@@ -27,11 +27,11 @@ import { validateResponseAsJSON, urlEncodeData } from '../utils'
 import { deriveNoteCreds } from '../utils/credentials'
 import 'isomorphic-fetch'
 
-async function fetchToken(client) {
+async function fetchToken(client, appName) {
   /* eslint-disable camelcase */
   const bodyData = {
     grant_type: 'password',
-    client_id: 'admin-cli',
+    client_id: appName,
   }
   /* eslint-enable */
 
@@ -103,7 +103,7 @@ export default class Client {
   async tokenInfo() {
     const fiveFromNow = Math.floor(Date.now() / 1000) + 5 * 60
     if (!this._tokenInfo || this._tokenInfo.expires < fiveFromNow) {
-      const tokenInfo = await fetchToken(this)
+      const tokenInfo = await fetchToken(this, this.config.appName)
       this._tokenInfo = tokenInfo
     }
     return this._tokenInfo

--- a/lib/identity/config.js
+++ b/lib/identity/config.js
@@ -53,17 +53,26 @@ export default class Config {
       }
     }
     const realmName = obj.realmName || obj.realm_name
+    const appName = obj.appName || obj.app_name
     const username = obj.username
     const userId = obj.userId || obj.user_id
     const apiUrl = obj.apiUrl || obj.api_url
     const brokerTargetUrl = obj.brokerTargetUrl || obj.broker_target_url
-    return new this(realmName, apiUrl, username, userId, brokerTargetUrl)
+    return new this(
+      realmName,
+      appName,
+      apiUrl,
+      username,
+      userId,
+      brokerTargetUrl
+    )
   }
 
   /**
    * Create a new instance of Config
    *
    * @param {string} realmName       The realms globally unique name
+   * @param {string} appName         The app identity will interact with.
    * @param {string} [apiUrl]        Optional base URL for the Tozny Platform API
    * @param {string} username        The user defined identifier for the user
    * @param {string} userId          A specific realm user's unique identifier
@@ -73,12 +82,24 @@ export default class Config {
    */
   constructor(
     realmName,
+    appName,
     apiUrl = DEFAULT_API_URL,
     username,
     userId,
     brokerTargetUrl
   ) {
+    if (!realmName) {
+      throw new Error(
+        'Realm name is required to use Tozny Identity services. If you need to create a realm, visit the Tozny Dashboard.'
+      )
+    }
+    if (!appName) {
+      throw new Error(
+        'App name is required to use Tozny Identity services. If you need to create an app, visit realm admin.'
+      )
+    }
     this.realmName = realmName
+    this.appName = appName
     this.username = username
     this.userId = userId
     this.apiUrl = apiUrl

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "e3db-client-interface",
-  "version": "2.0.0-alpha.0",
+  "version": "2.0.0-alpha.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "e3db-client-interface",
-  "version": "2.0.0-alpha.0",
+  "version": "2.0.0-alpha.1",
   "description": "JavaScript client interface for E3DB JS SDKs",
   "homepage": "https://github.com/tozny/js-sdk-client-interface",
   "author": {


### PR DESCRIPTION
After researching token issuing, the application id (Keycloak Client ID) can have a large affect on what tokens are issued, and the keys contained therein. To that end, this makes an app-id a required parameter in the identity config in the SDKs and uses this config when issuing token requests.