### PR TITLE
Override appName on login to use current configuration

### DIFF
--- a/lib/identity/index.js
+++ b/lib/identity/index.js
@@ -272,6 +272,9 @@ export default class Identity extends CryptoConsumer {
     )
 
     const user = this.fromObject(storedCreds.data)
+    // User can belong to multiple appNames (keycloak clients), but the app we're
+    // accessing is defined in our config not the config written at register time.
+    user.config.clone({ appName: this.config.appName })
 
     // Backwards compatibility for any identity user whose username was not
     // written to the credentials note.


### PR DESCRIPTION
Method assumes that whatever is in the credentials note is always a valid client configuration; However, the note's appName will never be used if the user uses the login method (encouraged path).