### PR TITLE
Complete recovery helper

### DIFF
--- a/lib/identity/index.js
+++ b/lib/identity/index.js
@@ -410,7 +410,7 @@ export default class Identity extends CryptoConsumer {
    *
    * @return{Promise<Client>} The recovered identity Client.
    */
-  completeRecovery(otp, noteId, recoveryUrl, recoveryType) {
+  completeRecovery(otp, noteId, recoveryUrl, recoveryType = 'email_otp') {
     /* eslint-disable camelcase */
     return this.completeBrokerLogin(
       { [recoveryType]: otp },

--- a/lib/identity/index.js
+++ b/lib/identity/index.js
@@ -202,7 +202,7 @@ export default class Identity extends CryptoConsumer {
       this.crypto,
       username,
       brokerKey,
-      'broker_email'
+      'email_otp'
     )
     /* eslint-disable camelcase */
     const brokerKeyNote = await idClient.storageClient.writeNote(
@@ -406,14 +406,14 @@ export default class Identity extends CryptoConsumer {
    * @param {string} otp The one-time password from the email challenge issued.
    * @param {string} noteId The ID of the note the email challenge was for.
    * @param {string} recoveryUrl The URL to send the recovery authentication to.
-   * @param {string} recoveryType The recovery type used either "tozny_otp" | "broker_email"
+   * @param {string} recoveryType The recovery type used either "tozny_otp" | "email_otp"
    *
    * @return{Promise<Client>} The recovered identity Client.
    */
   completeRecovery(otp, noteId, recoveryUrl, recoveryType) {
     /* eslint-disable camelcase */
     return this.completeBrokerLogin(
-      { email_otp: otp },
+      { [recoveryType]: otp },
       noteId,
       recoveryUrl,
       recoveryType
@@ -471,7 +471,7 @@ export default class Identity extends CryptoConsumer {
     authResponse,
     noteId,
     brokerUrl = `${this.config.apiUrl}/v1/identity/broker/realm/${this.config.realmName}/login`,
-    brokerType = 'broker_email'
+    brokerType = 'email_otp'
   ) {
     // Generate ephemeral keys for broker key transfer
     const cryptoKeys = await this.StorageClient.generateKeypair()

--- a/lib/identity/index.js
+++ b/lib/identity/index.js
@@ -244,7 +244,9 @@ export default class Identity extends CryptoConsumer {
       `broker_otp:${username}@realm:${this.config.realmName}`
     )
     const brokerToznyOTPKeyBytes = await this.crypto.randomBytes(64)
-    const brokerToznyOTPKey = await this.crypto.b64encode(brokerToznyOTPKeyBytes)
+    const brokerToznyOTPKey = await this.crypto.b64encode(
+      brokerToznyOTPKeyBytes
+    )
     const brokerToznyOTPNoteCreds = await deriveNoteCreds(
       this.config,
       this.crypto,
@@ -404,12 +406,18 @@ export default class Identity extends CryptoConsumer {
    * @param {string} otp The one-time password from the email challenge issued.
    * @param {string} noteId The ID of the note the email challenge was for.
    * @param {string} recoveryUrl The URL to send the recovery authentication to.
+   * @param {string} recoveryType The recovery type used either "tozny_otp" | "broker_email"
    *
    * @return{Promise<Client>} The recovered identity Client.
    */
-  completeRecovery(otp, noteId, recoveryUrl) {
+  completeRecovery(otp, noteId, recoveryUrl, recoveryType) {
     /* eslint-disable camelcase */
-    return this.completeBrokerLogin({ email_otp: otp }, noteId, recoveryUrl)
+    return this.completeBrokerLogin(
+      { email_otp: otp },
+      noteId,
+      recoveryUrl,
+      recoveryType
+    )
     /* eslint-enable */
   }
 

--- a/lib/utils/credentials.js
+++ b/lib/utils/credentials.js
@@ -7,7 +7,7 @@ import { IDENTITY_DERIVATION_ROUNDS } from './constants'
  * @param {Crypto} crypto The concrete Tozny crypto implementation.
  * @param {string} username The username credentials are being derived for.
  * @param {*} password The secret password for the user.
- * @param {*} credType The type of derived credentials for the note, options are `password`, `broker_email`, and `tozny_otp`.
+ * @param {*} credType The type of derived credentials for the note, options are `password`, `email_otp`, and `tozny_otp`.
  */
 export async function deriveNoteCreds(
   idConfig,
@@ -18,7 +18,7 @@ export async function deriveNoteCreds(
 ) {
   let nameSeed = `${username}@realm:${idConfig.realmName}`
   switch (credType) {
-    case 'broker_email':
+    case 'email_otp':
       nameSeed = `broker:${nameSeed}`
       break
     case 'tozny_otp':


### PR DESCRIPTION
Implements the recovery helper method.

Attempts to standardize the strings we use when calling this method. The backend service expects email_otp or tozny_otp at the moment, so having broker_email makes usability difficult.

Note: The JS SDK is currently the authoritative spec/standard for registering identities and naming sprawl might make maintenance hard until we get notes with AND|OR eacps